### PR TITLE
Added configuration to select dom object other than window and top docum...

### DIFF
--- a/src/wow.coffee
+++ b/src/wow.coffee
@@ -107,6 +107,8 @@ class @WOW
     mobile:       true
     live:         true
     callback:     null
+    scrollElement: window.document.documentElement
+    resizeElement: window
 
   constructor: (options = {}) ->
     @scrolled = true
@@ -133,8 +135,8 @@ class @WOW
       else
         @applyStyle(box, true) for box in @boxes
     if !@disabled()
-      @util().addEvent window, 'scroll', @scrollHandler
-      @util().addEvent window, 'resize', @scrollHandler
+      @util().addEvent @config.scrollElement, 'scroll', @scrollHandler
+      @util().addEvent @config.resizeElement, 'resize', @scrollHandler
       @interval = setInterval @scrollCallback, 50
     if @config.live
       new MutationObserver (records) =>
@@ -147,8 +149,8 @@ class @WOW
   # unbind the scroll event
   stop: ->
     @stopped = true
-    @util().removeEvent window, 'scroll', @scrollHandler
-    @util().removeEvent window, 'resize', @scrollHandler
+    @util().removeEvent @config.scrollElement, 'scroll', @scrollHandler
+    @util().removeEvent @config.resizeElement, 'resize', @scrollHandler
     clearInterval @interval if @interval?
 
   sync: (element) ->
@@ -273,7 +275,7 @@ class @WOW
   # check if box is visible
   isVisible: (box) ->
     offset     = box.getAttribute('data-wow-offset') or @config.offset
-    viewTop    = window.pageYOffset
+    viewTop    = @config.scrollElement.pageYOffset || @config.scrollElement.scrollTop || window.pageYOffset
     viewBottom = viewTop + Math.min(@element.clientHeight, @util().innerHeight()) - offset
     top        = @offsetTop(box)
     bottom     = top + box.clientHeight


### PR DESCRIPTION
I had a situation where the window was scrolling because it was an inside DOM object. Not sure if this is javascript kosher, but I added a couple of configuration options to handle the case if you needed service scroll events on something other than the main window and top level documentElement.